### PR TITLE
Fix version compatibility for HF example

### DIFF
--- a/deployment/baseten_huggingface.ipynb
+++ b/deployment/baseten_huggingface.ipynb
@@ -19,7 +19,7 @@
       },
       "outputs": [],
       "source": [
-        "%pip install --upgrade transformers baseten"
+        "%pip install --upgrade transformers==4.28.1 baseten pillow==9.4.0"
       ]
     },
     {


### PR DESCRIPTION
# What

It appears the latest version of transformers (4.28.1) is incompatible w/ the latest version of Pillow (9.5.0). Hopefully future versions of xformers will fix this.

We don't pin baseten for now, but I will set up cal events in the future to ensure that these aren't broken.