### PR TITLE
Fix sklearn install command

### DIFF
--- a/deployment/baseten_sklearn.ipynb
+++ b/deployment/baseten_sklearn.ipynb
@@ -19,7 +19,7 @@
       },
       "outputs": [],
       "source": [
-        "%pip install --upgrade sklearn baseten"
+        "%pip install --upgrade scikit-learn==1.2.2 baseten"
       ]
     },
     {


### PR DESCRIPTION
sklearn is no longer called "sklearn" on pypi:


```
[~]$ pip install --upgrade sklearn
Requirement already satisfied: sklearn in ./.asdf/installs/python/3.9.11/lib/python3.9/site-packages (0.0.post1)
Collecting sklearn
  Downloading sklearn-0.0.post4.tar.gz (3.6 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
```